### PR TITLE
Insert fee and co-owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ node_modules
 
 # Hardhat Ignition default folder for deployments against a local node
 ignition/deployments/chain-31337
+
+**/.DS_Store

--- a/contracts/core/KnowledgeMarket.sol
+++ b/contracts/core/KnowledgeMarket.sol
@@ -12,8 +12,9 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 contract KnowledgeMarket is ERC4908, ReentrancyGuard {
     // Default image URL used when no image is provided
     string private constant DEFAULT_IMAGE_URL = "https://arweave.net/9u0cgTmkSM25PfQpGZ-JzspjOMf4uGFjkvOfKjgQnVY";
-    uint32 public PLATFORM_FEE = 1200;
+    uint32 public PLATFORM_FEE;
     address payable public platformTreasury;
+    bool private _initialized;
 
     struct Subscription {
         string vaultId;
@@ -47,9 +48,15 @@ contract KnowledgeMarket is ERC4908, ReentrancyGuard {
     event SubscriptionDeleted(address indexed vaultOwner, string vaultId);
     event AccessGranted(address indexed vaultOwner, string vaultId, address indexed customer, uint256 tokenId, uint256 price);
 
-    constructor(address payable initialTreasury) ERC4908("Knowledge Market Access", "KMA") {
-        if (initialTreasury == address(0)) revert ZeroAddress();
-        platformTreasury = initialTreasury;
+    constructor() ERC4908("Knowledge Market Access", "KMA") { }
+
+    function initialize(address payable treasury) public {
+        if (_initialized) revert("Contract already initialized");
+        if (treasury == address(0)) revert ZeroAddress();
+
+        platformTreasury = treasury;
+        PLATFORM_FEE = 1200;
+        _initialized = true;
     }
 
     /**
@@ -167,6 +174,7 @@ contract KnowledgeMarket is ERC4908, ReentrancyGuard {
         (uint256 basePrice, , address coOwner, uint32 splitFee) = this.getAccessControl(vaultOwner, vaultId);
         
         if (msg.value < basePrice) revert InsufficientFunds(basePrice);
+        if (msg.value > basePrice) payable(msg.sender).transfer(msg.value - basePrice); // Refund excess
 
         uint256 platformFee = (basePrice * PLATFORM_FEE) / 10000;
         uint256 creatorAmount = basePrice - platformFee;

--- a/contracts/test/TestKnowledgeMarket.sol
+++ b/contracts/test/TestKnowledgeMarket.sol
@@ -9,7 +9,7 @@ import "../core/KnowledgeMarket.sol";
  * Functionally identical to KnowledgeMarket but with a hash-like name for the token
  */
 contract TestKnowledgeMarket is KnowledgeMarket {
-    constructor() KnowledgeMarket() {
+    constructor(address payable initialTreasury) KnowledgeMarket(initialTreasury) {
         // Override the name and symbol from the parent constructor
         // Note: This is a pattern to simulate having a different contract name
         // In a real-world scenario, you might want to use a proxy pattern instead

--- a/contracts/test/TestKnowledgeMarket.sol
+++ b/contracts/test/TestKnowledgeMarket.sol
@@ -9,7 +9,7 @@ import "../core/KnowledgeMarket.sol";
  * Functionally identical to KnowledgeMarket but with a hash-like name for the token
  */
 contract TestKnowledgeMarket is KnowledgeMarket {
-    constructor(address payable initialTreasury) KnowledgeMarket(initialTreasury) {
+    constructor() KnowledgeMarket() {
         // Override the name and symbol from the parent constructor
         // Note: This is a pattern to simulate having a different contract name
         // In a real-world scenario, you might want to use a proxy pattern instead

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,7 +7,15 @@ dotenv.config();
 const DEPLOYER_PRIVATE_KEY = process.env.DEPLOYER_KEY || "";
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.28",
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200
+      }
+    }
+  },
   networks: {
     baseSepolia: {
       url: "https://sepolia.base.org",

--- a/scripts/deploy-knowledge-market.ts
+++ b/scripts/deploy-knowledge-market.ts
@@ -1,13 +1,18 @@
 import { ethers } from "hardhat";
 
 async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log("Deploying with account:", deployer.address);
+  console.log("Account balance:", (await deployer.provider!.getBalance(deployer.address)).toString());
+
   console.log("Deploying KnowledgeMarket contract...");
   
   // Get the contract factory
   const KnowledgeMarket = await ethers.getContractFactory("KnowledgeMarket");
   
   // Deploy the contract
-  const knowledgeMarket = await KnowledgeMarket.deploy();
+  const knowledgeMarket = await KnowledgeMarket.deploy(deployer.address);
   
   // Wait for deployment to complete
   await knowledgeMarket.waitForDeployment();

--- a/scripts/deploy-knowledge-market.ts
+++ b/scripts/deploy-knowledge-market.ts
@@ -12,7 +12,7 @@ async function main() {
   const KnowledgeMarket = await ethers.getContractFactory("KnowledgeMarket");
   
   // Deploy the contract
-  const knowledgeMarket = await KnowledgeMarket.deploy(deployer.address);
+  const knowledgeMarket = await KnowledgeMarket.deploy();
   
   // Wait for deployment to complete
   await knowledgeMarket.waitForDeployment();

--- a/scripts/deploy-upgradeable-proxy.ts
+++ b/scripts/deploy-upgradeable-proxy.ts
@@ -34,6 +34,16 @@ async function main() {
   await proxyWithInterface.changeAdmin(proxyAdminAddress);
   console.log(`   Proxy admin transferred to: ${proxyAdminAddress}`);
 
+  // 5. Initialize the proxy with the desired initial values
+  console.log("5. Initializing KnowledgeMarket via proxy...");
+
+  const [deployer] = await ethers.getSigners();
+
+  const initialTreasuryAddress = deployer.address; // Replace with the actual treasury address
+
+  const proxyAsKnowledgeMarket = await ethers.getContractAt("KnowledgeMarket", proxyAddress);
+  await proxyAsKnowledgeMarket.initialize(initialTreasuryAddress);
+
   console.log("\nDeployment completed successfully!");
   console.log("==============================================");
   console.log(`You can interact with KnowledgeMarket through the proxy at: ${proxyAddress}`);

--- a/scripts/test-proxy.ts
+++ b/scripts/test-proxy.ts
@@ -45,11 +45,21 @@ async function main() {
     config.vaultId,
     config.price,
     config.expirationDuration,
-    config.imageUrl
+    config.imageUrl,
+    config.coOwner,
+    config.splitFee
   );
-  
+  console.log(`Subscription transaction: ${subscriptionTx}`);
+
   // 3. Verify the subscription was created
   const subscriptionVerified = await verifySubscription(knowledgeMarket, config.vaultId, deployer.address);
+
+  if (subscriptionVerified) {
+    console.log("\nSubscription created and verified successfully!");
+  } else {
+    console.error("\nSubscription verification failed!");
+    process.exit(1);
+  }
   
   console.log("\n=== PART 2: MINTING TEST ===");
   

--- a/scripts/test-subscription.ts
+++ b/scripts/test-subscription.ts
@@ -35,7 +35,9 @@ async function main() {
     config.vaultId,
     config.price,
     config.expirationDuration,
-    config.imageUrl
+    config.imageUrl,
+    config.coOwner,
+    config.splitFee
   );
   
   // 3. Verify the subscription was created

--- a/scripts/utils/proxy-test-utils.ts
+++ b/scripts/utils/proxy-test-utils.ts
@@ -46,7 +46,9 @@ export async function createSubscription(
   vaultId: string,
   price: bigint,
   expirationDuration: number,
-  imageUrl: string
+  imageUrl: string,
+  coOwner: string,
+  splitFee: bigint = BigInt(0)
 ): Promise<ContractTransactionResponse | null> {
   console.log("\nStep 2: Creating a subscription");
   console.log(`Creating subscription with vaultId: ${vaultId}, price: ${price}`);
@@ -56,7 +58,9 @@ export async function createSubscription(
       vaultId,
       price,
       expirationDuration,
-      imageUrl
+      imageUrl,
+      coOwner,
+      splitFee
     );
     
     console.log("Transaction submitted. Waiting for confirmation...");
@@ -221,14 +225,18 @@ export const NETWORKS = {
     price: ethers.parseEther("0.001"),
     expirationDuration: 60 * 60 * 24 * 30, // 30 days
     imageUrl: "https://example.com/mainnet-test-image.jpg",
+    coOwner: ethers.ZeroAddress, // No co-owner for mainnet test
+    splitFee: BigInt(0), // No split fee for mainnet test
     network: "baseMainnet"
   },
   baseSepolia: {
-    proxyAddress: "0x05889371937b66D9588C5C75be56CE0707bdFcf2",
+    proxyAddress: "0xf364655bE21a8F274dc97fF277E7C06DE3b5AbA1",
     vaultId: "test-knowledge-vault-123",
     price: ethers.parseEther("0.001"),
     expirationDuration: 60 * 60 * 24 * 30, // 30 days
     imageUrl: "https://example.com/test-image.jpg",
+    coOwner: ethers.ZeroAddress, // No co-owner for mainnet test
+    splitFee: BigInt(0), // No split fee for mainnet test
     network: "baseSepolia"
   }
 }; 

--- a/test/unit/KnowledgeMarket.test.ts
+++ b/test/unit/KnowledgeMarket.test.ts
@@ -15,6 +15,8 @@ describe("KnowledgeMarket", function () {
   const IMAGE_URL = "https://example.com/image.jpg";
   const PRICE = ethers.parseEther("0.1"); // 0.1 ETH
   const EXPIRATION_DURATION = 86400; // 1 day in seconds
+  const COOWNER = ethers.ZeroAddress; // No co-owner for this test
+  const COOWNER_SHARE = ethers.toBigInt(0); // No co-owner share for this test 
 
   beforeEach(async function () {
     [owner, vaultOwner, user, anotherUser] = await ethers.getSigners();
@@ -26,7 +28,7 @@ describe("KnowledgeMarket", function () {
 
     // Deploy knowledge market contract
     const KnowledgeMarket = await ethers.getContractFactory("KnowledgeMarket");
-    knowledgeMarket = await KnowledgeMarket.deploy();
+    knowledgeMarket = await KnowledgeMarket.deploy(owner.address);
     await knowledgeMarket.waitForDeployment();
 
     // Mint NFT to user
@@ -39,7 +41,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
 
       const subscriptions = await knowledgeMarket.getVaultOwnerSubscriptions(vaultOwner.address);
@@ -48,6 +52,29 @@ describe("KnowledgeMarket", function () {
       expect(subscriptions[0].imageURL).to.equal(IMAGE_URL);
       expect(subscriptions[0].price).to.equal(PRICE);
       expect(subscriptions[0].expirationDuration).to.equal(EXPIRATION_DURATION);
+      expect(subscriptions[0].coOwner).to.equal(COOWNER);
+      expect(subscriptions[0].splitFee).to.equal(COOWNER_SHARE);
+    });
+
+    it("Should allow changing the co-owner address and fee", async function () {
+      const newCoOwnerShare = ethers.toBigInt(6000); // 60% share
+      await knowledgeMarket.connect(vaultOwner).setSubscription(
+        VAULT_ID,
+        PRICE,
+        EXPIRATION_DURATION,
+        IMAGE_URL,
+        anotherUser.address,
+        newCoOwnerShare
+      );
+      
+      const subscriptions = await knowledgeMarket.getVaultOwnerSubscriptions(vaultOwner.address);
+      expect(subscriptions.length).to.equal(1);
+      expect(subscriptions[0].vaultId).to.equal(VAULT_ID);
+      expect(subscriptions[0].imageURL).to.equal(IMAGE_URL);
+      expect(subscriptions[0].price).to.equal(PRICE);
+      expect(subscriptions[0].expirationDuration).to.equal(EXPIRATION_DURATION);
+      expect(subscriptions[0].coOwner).to.equal(anotherUser.address);
+      expect(subscriptions[0].splitFee).to.equal(newCoOwnerShare);
     });
 
     it("Should allow deleting a subscription", async function () {
@@ -56,7 +83,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
 
       // Then delete it
@@ -72,7 +101,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        "" // Empty image URL
+        "", // Empty image URL
+        COOWNER,
+        COOWNER_SHARE
       );
 
       // Mint with this subscription
@@ -95,7 +126,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       ))
       .to.emit(knowledgeMarket, "SubscriptionCreated")
       .withArgs(vaultOwner.address, VAULT_ID, PRICE, EXPIRATION_DURATION);
@@ -107,7 +140,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
 
       // Then delete it and check for event
@@ -122,7 +157,9 @@ describe("KnowledgeMarket", function () {
           "", // Empty vaultId
           PRICE,
           EXPIRATION_DURATION,
-          IMAGE_URL
+          IMAGE_URL,
+          COOWNER,
+          COOWNER_SHARE
         )
       ).to.be.revertedWithCustomError(knowledgeMarket, "EmptyVaultId");
     });
@@ -133,7 +170,9 @@ describe("KnowledgeMarket", function () {
         "freeVault",
         0, // Zero price
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
 
       const subscriptions = await knowledgeMarket.getVaultOwnerSubscriptions(vaultOwner.address);
@@ -164,7 +203,9 @@ describe("KnowledgeMarket", function () {
           VAULT_ID,
           PRICE,
           0, // Zero duration
-          IMAGE_URL
+          IMAGE_URL,
+          COOWNER,
+          COOWNER_SHARE
         )
       ).to.be.revertedWithCustomError(knowledgeMarket, "ZeroDuration");
     });
@@ -192,7 +233,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
     });
 
@@ -210,6 +253,89 @@ describe("KnowledgeMarket", function () {
       expect(deal.imageURL).to.equal(IMAGE_URL);
       expect(deal.price).to.equal(PRICE);
     });
+
+    it("Should send 12% platform fee to the platformTreasury", async function () {
+      const treasuryAddress = await knowledgeMarket.platformTreasury();
+      const initialBalance = await ethers.provider.getBalance(treasuryAddress);
+
+      const PLATFORM_FEE = await knowledgeMarket.PLATFORM_FEE(); // 1200 (12%)
+
+      const tx = await knowledgeMarket.connect(user).mint(
+        vaultOwner.address,
+        VAULT_ID,
+        user.address,
+        { value: PRICE }
+      );
+      await tx.wait();
+
+      const finalBalance = await ethers.provider.getBalance(treasuryAddress);
+      const expectedFee = (PRICE * PLATFORM_FEE) / 10000n;
+      expect(finalBalance - initialBalance).to.equal(expectedFee);
+    });
+
+    it("Should fail if platform receives less than expected fee", async function () {
+      const treasuryAddress = await knowledgeMarket.platformTreasury();
+      const initialBalance = await ethers.provider.getBalance(treasuryAddress);
+
+      const wrongFee = ((PRICE * 1100n) / 10000n); // 11%
+
+      const tx = await knowledgeMarket.connect(user).mint(
+        vaultOwner.address,
+        VAULT_ID,
+        user.address,
+        { value: PRICE }
+      );
+      await tx.wait();
+
+      const finalBalance = await ethers.provider.getBalance(treasuryAddress);
+      const actualFee = finalBalance - initialBalance;
+
+      expect(actualFee).to.not.equal(wrongFee);
+    });
+
+
+    it("Should send correct creator amount to the vaultOwner", async function () {
+      const vaultOwnerInitialBalance = (await ethers.provider.getBalance(vaultOwner.address));
+
+      const PLATFORM_FEE = await knowledgeMarket.PLATFORM_FEE(); // 1200 (12%)
+
+      const tx = await knowledgeMarket.connect(user).mint(
+        vaultOwner.address,
+        VAULT_ID,
+        user.address,
+        { value: PRICE }
+      );
+      await tx.wait();
+
+      const vaultOwnerFinalBalance = (await ethers.provider.getBalance(vaultOwner.address));
+
+      const expectedPlatformFee = (PRICE * PLATFORM_FEE) / 10000n;
+      const expectedCreatorAmount = PRICE - expectedPlatformFee;
+
+      expect(vaultOwnerFinalBalance - vaultOwnerInitialBalance).to.equal(expectedCreatorAmount);
+    });
+
+    it("Should fail if vaultOwner receives an incorrect creator amount", async function () {
+      const vaultOwnerInitialBalance = await ethers.provider.getBalance(vaultOwner.address);
+
+      const tx = await knowledgeMarket.connect(user).mint(
+        vaultOwner.address,
+        VAULT_ID,
+        user.address,
+        { value: PRICE }
+      );
+      await tx.wait();
+
+      const vaultOwnerFinalBalance = await ethers.provider.getBalance(vaultOwner.address);
+
+      const wrongPlatformFee = (PRICE * 1100n) / 10000n; // 11%
+      const wrongCreatorAmount = PRICE - wrongPlatformFee;
+
+      const receivedAmount = vaultOwnerFinalBalance - vaultOwnerInitialBalance;
+
+      expect(receivedAmount).to.not.equal(wrongCreatorAmount);
+    });
+
 
     it("Should fail if payment amount is incorrect", async function () {
       const wrongPrice = PRICE - ethers.parseEther("0.01"); // Less than required price
@@ -272,6 +398,79 @@ describe("KnowledgeMarket", function () {
     });
   });
 
+  describe("Minting with Co-Owner", async function () {
+    const COOWNER_SHARE = ethers.toBigInt(5000); // 50% share
+    beforeEach(async function () {
+      // Set up a subscription with co-owner
+      await knowledgeMarket.connect(vaultOwner).setSubscription(
+        VAULT_ID,
+        PRICE,
+        EXPIRATION_DURATION,
+        IMAGE_URL,
+        anotherUser.address,
+        COOWNER_SHARE
+      );
+    });
+
+    it("Should allow minting with co-owner", async function () {
+      const initialCoOwnerBalance = await ethers.provider.getBalance(anotherUser.address);
+      const initialVaultOwnerBalance = await ethers.provider.getBalance(vaultOwner.address);
+
+      await knowledgeMarket.connect(user).mint(
+        vaultOwner.address,
+        VAULT_ID,
+        user.address,
+        { value: PRICE }
+      );
+
+      const PLATFORM_FEE = await knowledgeMarket.PLATFORM_FEE(); 
+
+      const accessControl = await knowledgeMarket.getAccessControl(vaultOwner.address, VAULT_ID);
+      expect(accessControl.coOwner).to.equal(anotherUser.address);
+      expect(accessControl.splitFee).to.equal(COOWNER_SHARE);
+
+      const finalCoOwnerBalance = await ethers.provider.getBalance(anotherUser.address);
+      const finalVaultOwnerBalance = await ethers.provider.getBalance(vaultOwner.address);
+
+      // Calculate expected co-owner amount
+      const platformFee = (PRICE * PLATFORM_FEE) / 10000n;
+      const remaining = PRICE - platformFee;
+      const expectedCoOwnerAmount = (remaining * COOWNER_SHARE) / 10000n;
+      const expectedVaultOwnerAmount = remaining - expectedCoOwnerAmount;
+      
+      expect(finalVaultOwnerBalance - initialVaultOwnerBalance).to.equal(expectedVaultOwnerAmount);
+      expect(finalCoOwnerBalance - initialCoOwnerBalance).to.equal(expectedCoOwnerAmount);
+    });
+
+    it("Should fail if co-owner fee is greater than 10000", async function () {
+      const invalidCoOwnerShare = ethers.toBigInt(11000);
+      await expect(
+        knowledgeMarket.connect(vaultOwner).setSubscription(
+          VAULT_ID,
+          PRICE,
+          EXPIRATION_DURATION,
+          IMAGE_URL,
+          anotherUser.address,
+          invalidCoOwnerShare
+        )
+      ).to.be.revertedWithCustomError(knowledgeMarket, "InvalidSplitFee");
+    });
+
+    it("Should fail if owner and co-owner are the same", async function () {
+      await expect(
+        knowledgeMarket.connect(vaultOwner).setSubscription(
+          VAULT_ID,
+          PRICE,
+          EXPIRATION_DURATION,
+          IMAGE_URL,
+          vaultOwner.address, // Same address as co-owner
+          COOWNER_SHARE
+        )
+      ).to.be.revertedWithCustomError(knowledgeMarket, "SameOwnerAndCoOwner");
+    });
+
+  });
+
   describe("Access Control", function () {
     beforeEach(async function () {
       // Set up a subscription first
@@ -279,7 +478,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
     });
 
@@ -345,7 +546,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
 
       // Mint an NFT
@@ -386,7 +589,9 @@ describe("KnowledgeMarket", function () {
         VAULT_ID,
         PRICE,
         EXPIRATION_DURATION,
-        IMAGE_URL
+        IMAGE_URL,
+        COOWNER,
+        COOWNER_SHARE
       );
       
       // Add second subscription
@@ -394,7 +599,9 @@ describe("KnowledgeMarket", function () {
         "vault456",
         PRICE * 2n,
         EXPIRATION_DURATION * 2,
-        "https://example.com/image2.jpg"
+        "https://example.com/image2.jpg",
+        COOWNER,
+        COOWNER_SHARE
       );
       
       const subscriptions = await knowledgeMarket.getVaultOwnerSubscriptions(vaultOwner.address);

--- a/test/unit/KnowledgeMarket.test.ts
+++ b/test/unit/KnowledgeMarket.test.ts
@@ -28,7 +28,7 @@ describe("KnowledgeMarket", function () {
 
     // Deploy knowledge market contract
     const KnowledgeMarket = await ethers.getContractFactory("KnowledgeMarket");
-    knowledgeMarket = await KnowledgeMarket.deploy(owner.address);
+    knowledgeMarket = await KnowledgeMarket.deploy();
     await knowledgeMarket.waitForDeployment();
 
     // Mint NFT to user

--- a/test/unit/KnowledgeMarketProxy.test.ts
+++ b/test/unit/KnowledgeMarketProxy.test.ts
@@ -21,7 +21,7 @@ describe("KnowledgeMarketProxy", function () {
   beforeEach(async function () {
     // Deploy KnowledgeMarket implementation
     const KnowledgeMarket = await ethers.getContractFactory("KnowledgeMarket");
-    knowledgeMarket = await KnowledgeMarket.deploy();
+    knowledgeMarket = await KnowledgeMarket.deploy(owner.address);
     await knowledgeMarket.waitForDeployment();
     const knowledgeMarketAddress = await knowledgeMarket.getAddress();
 
@@ -75,7 +75,7 @@ describe("KnowledgeMarketProxy", function () {
     
     // Deploy a second version of the implementation
     const KnowledgeMarketV2 = await ethers.getContractFactory("KnowledgeMarket");
-    knowledgeMarketV2 = await KnowledgeMarketV2.deploy();
+    knowledgeMarketV2 = await KnowledgeMarketV2.deploy(owner.address);
     await knowledgeMarketV2.waitForDeployment();
     const knowledgeMarketV2Address = await knowledgeMarketV2.getAddress();
     
@@ -102,7 +102,7 @@ describe("KnowledgeMarketProxy", function () {
     const imageURL = "https://example.com/image.jpg";
     
     // Call setSubscription via the proxy
-    await knowledgeMarketAtProxy.setSubscription(vaultId, price, expirationDuration, imageURL);
+    await knowledgeMarketAtProxy.setSubscription(vaultId, price, expirationDuration, imageURL, ethers.ZeroAddress, 0);
     
     // Verify the subscription was set by reading from the proxy
     const subscriptions = await knowledgeMarketAtProxy.getVaultOwnerSubscriptions(owner.address);


### PR DESCRIPTION
The new features planned for this contract depend on the update of an external contract, as described in this https://github.com/Sentiment-trader/erc-4908/pull/1

The contract currently deployed and under testing on IPAL does not use an upgradeable proxy mechanism, which means it cannot be modified or upgraded after deployment. As a result, the tests are being conducted on a static version of the contract.

I am still reviewing and aiming to better understand the upgradeable proxy pattern, in order to implement a contract that can be securely and efficiently updated in the future.